### PR TITLE
global: remove reana-workflow-commons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt update && \
 
 COPY CHANGES.rst README.rst setup.py /code/
 COPY reana_workflow_engine_serial/version.py /code/reana_workflow_engine_serial/
-RUN pip install -e git://github.com/reanahub/reana-workflow-commons.git@master#egg=reana-workflow-commons
+RUN pip install -e git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
 WORKDIR /code
 RUN pip install --no-cache-dir requirements-builder && \
     requirements-builder -e all -l pypi setup.py | pip install --no-cache-dir -r /dev/stdin && \

--- a/reana_workflow_engine_serial/tasks.py
+++ b/reana_workflow_engine_serial/tasks.py
@@ -27,7 +27,7 @@ import logging
 import os
 from time import sleep
 
-from reana_workflow_commons.publisher import Publisher
+from reana_commons.publisher import Publisher
 
 from .api_client import create_openapi_client
 from .celeryapp import app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 wdb
 ipdb
 Flask-DebugToolbar
-git+git://github.com/reanahub/reana-workflow-commons.git#egg=reana-workflow-commons
+git+git://github.com/reanahub/reana-commons.git#egg=reana-commons

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     'bravado>=9.0.6',
     'celery>=4.1.0',
     'pika==0.11.2',
-    'reana-workflow-commons>=0.3.0.dev20180703'
+    'reana-commons>=0.3.0.dev20180418'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Removes reana-workflow-commons as a dependency and adds
  reana-commons.

Connects https://github.com/reanahub/reana-workflow-commons/issues/4

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>