### PR TITLE
installation: setup.py for REANA-Commons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt update && \
 
 COPY CHANGES.rst README.rst setup.py /code/
 COPY reana_workflow_engine_serial/version.py /code/reana_workflow_engine_serial/
-RUN pip install -e git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
+
 WORKDIR /code
 RUN pip install --no-cache-dir requirements-builder && \
     requirements-builder -e all -l pypi setup.py | pip install --no-cache-dir -r /dev/stdin && \

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     'bravado>=9.0.6',
     'celery>=4.1.0',
     'pika>=0.11.2',
-    'reana-commons>=0.3.0'
+    'reana-commons>=0.3.1,<0.4'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Uses only `setup.py` to install REANA-Commons dependency and introduces upper
  boundary for its version. (addresses reanahub/reana#80)

* Removes installation of its `master` versions from `Dockerfile`.
  (closes #35)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>