### PR TITLE
installation: REANA dependencies version limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN apt update && \
 
 COPY CHANGES.rst README.rst setup.py /code/
 COPY reana_workflow_engine_serial/version.py /code/reana_workflow_engine_serial/
-RUN pip install -e git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
 WORKDIR /code
 RUN pip install --no-cache-dir requirements-builder && \
     requirements-builder -e all -l pypi setup.py | pip install --no-cache-dir -r /dev/stdin && \

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     'bravado>=9.0.6',
     'celery>=4.1.0',
     'pika>=0.11.2',
-    'reana-commons>=0.3.0'
+    'reana-commons>=0.3.1,<0.4',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Removes installation of REANA-Commons from git master (closes #35).

* Introduces upper boundary for REANA-Commons dependency
  (addresses reanahub/reana#80).