### PR TITLE
installation: more version limits

### DIFF
--- a/reana_workflow_engine_serial/version.py
+++ b/reana_workflow_engine_serial/version.py
@@ -28,4 +28,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.3.0"
+__version__ = "0.3.1.dev20180905"

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup_requires = [
 ]
 
 install_requires = [
-    'bravado>=9.0.6',
-    'celery>=4.1.0',
+    'bravado>=9.0.6,<10.2',
+    'celery>=4.1.0,<4.3',
     'pika>=0.11.2',
     'reana-commons>=0.3.1,<0.4'
 ]


### PR DESCRIPTION
* Introduces more upper boundary limits for selected important
  dependencies (Bravado, Celery) for the cluster components.
  (addresses reanahub/reana#80)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>