### PR TITLE
installation: let R-Commons manage bravado version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,9 @@ setup_requires = [
 ]
 
 install_requires = [
-    'bravado>=9.0.6,<10.2',
     'celery>=4.1.0,<4.3',
     'click>=7,<8',
-    'reana-commons[kubernetes]>=0.5.0.dev20190402,<0.6.0'
+    'reana-commons[kubernetes]>=0.5.0.dev20190408,<0.6.0'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* We need `bravado>10.2` for the [`ssl_verify` to work](https://github.com/reanahub/reana-commons/pull/108), which is already defined in `reana-commons`.