### PR TITLE
tasks: adds connectivity to job controller check

### DIFF
--- a/reana_workflow_engine_serial/tasks.py
+++ b/reana_workflow_engine_serial/tasks.py
@@ -22,7 +22,8 @@ from reana_commons.config import (REANA_LOG_LEVEL,
 from reana_commons.publisher import WorkflowStatusPublisher
 from reana_commons.serial import serial_load
 from reana_commons.utils import (build_caching_info_message,
-                                 build_progress_message)
+                                 build_progress_message,
+                                 check_connection_to_job_controller)
 
 from .config import SHARED_VOLUME_PATH
 from .utils import (build_job_spec,
@@ -67,6 +68,7 @@ def run_serial_workflow(workflow_uuid,
                         operational_options=None):
     """Run a serial workflow."""
     try:
+        check_connection_to_job_controller()
         workflow_workspace, publisher, cache_enabled, = initialize(
             workflow_uuid,
             workflow_workspace,

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup_requires = [
 install_requires = [
     'celery>=4.1.0,<4.3',
     'click>=7',
-    'reana-commons>=0.5.0,<0.6.0'
+    'reana-commons>=0.6.0.dev20190619,<0.7.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* When job controller and workflow engines run in the same pod,
  workflow engine has to ensure that job controller is ready to
  receive requests.
  Connects reanahub/reana-job-controller/issues/105

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>