### PR TITLE
serial: add kubernetes_uid field

### DIFF
--- a/reana_workflow_engine_serial/tasks.py
+++ b/reana_workflow_engine_serial/tasks.py
@@ -172,7 +172,8 @@ def run_step(step_number,
             workflow_workspace=workflow_workspace,
             workflow_uuid=workflow_uuid,
             kerberos=step.get('kerberos', False),
-            unpacked_image=step.get('unpacked_image', False))
+            unpacked_image=step.get('unpacked_image', False),
+            kubernetes_uid=step.get('kubernetes_uid', None))
         job_spec_copy = dict(job_spec)
         job_spec_copy['cmd'] = sanitize_command(job_spec_copy['cmd'])
 

--- a/reana_workflow_engine_serial/utils.py
+++ b/reana_workflow_engine_serial/utils.py
@@ -47,7 +47,7 @@ def escape_shell_arg(shell_arg):
 
 def build_job_spec(job_name, image, compute_backend, command,
                    workflow_workspace, workflow_uuid, kerberos,
-                   unpacked_image):
+                   unpacked_image, kubernetes_uid):
     """Build job specification to passed to RJC."""
     job_spec = {
         "image": image,
@@ -61,6 +61,7 @@ def build_job_spec(job_name, image, compute_backend, command,
         "workflow_uuid": workflow_uuid,
         "kerberos": kerberos,
         "unpacked_img": unpacked_image,
+        "kubernetes_uid": kubernetes_uid,
     }
     return job_spec
 


### PR DESCRIPTION
Add kubernetes_uid field to serial workflow to allow user to specify the Kubernetes runtime user ID

closes reanahub/reana-workflow-engine-serial#106