### PR TITLE
global: rename job status succeeded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.7.3 (UNRELEASED)
+--------------------------
+
+- Changes workflow engine instantiation to use central REANA-Commons factory.
+
 Version 0.7.2 (2021-02-03)
 --------------------------
 

--- a/reana_workflow_engine_serial/tasks.py
+++ b/reana_workflow_engine_serial/tasks.py
@@ -92,7 +92,7 @@ def run(
             publisher,
             workflow_uuid,
         )
-        if status != "succeeded":
+        if status != "finished":
             break
 
 
@@ -155,7 +155,7 @@ def run_step(
         )
 
         job_status = poll_job_status(rjc_api_client, job_id)
-        if job_status.status == "succeeded":
+        if job_status.status == "finished":
             cache_dir_path = None
             if cache_enabled:
                 cache_dir_path = copy_workspace_to_cache(job_id, workflow_workspace)

--- a/reana_workflow_engine_serial/utils.py
+++ b/reana_workflow_engine_serial/utils.py
@@ -121,13 +121,13 @@ def publish_cache_copy(
         workflow_status = 2
     else:
         workflow_status = 1
-    succeeded_jobs = {"total": 1, "job_ids": [job_id]}
+    finished_jobs = {"total": 1, "job_ids": [job_id]}
     publisher.publish_workflow_status(
         workflow_uuid,
         workflow_status,
         message={
             "progress": build_progress_message(
-                finished=succeeded_jobs, cached=succeeded_jobs
+                finished=finished_jobs, cached=finished_jobs
             )
         },
     )
@@ -156,7 +156,7 @@ def poll_job_status(rjc_api_client, job_id):
     """Poll for job status."""
     job_status = rjc_api_client.check_status(job_id)
 
-    while job_status.status not in ["succeeded", "failed"]:
+    while job_status.status not in ["finished", "failed"]:
         job_status = rjc_api_client.check_status(job_id)
         sleep(JOB_STATUS_POLLING_INTERVAL)
 


### PR DESCRIPTION
* Renames ``succeeded`` to ``finished`` as the latter is the one
  described centrally in ``reana_db.models.WorkflowStatus`` and
  ``reana_db.models.JobStatus``.