### PR TITLE
tasks: modify  workspace_path to store full path

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 
 - `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
+- `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_

--- a/reana_workflow_engine_serial/tasks.py
+++ b/reana_workflow_engine_serial/tasks.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, print_function
 import logging
 import os
 
-from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL, SHARED_VOLUME_PATH
+from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
 from reana_commons.serial import serial_load
 from reana_commons.workflow_engine import create_workflow_engine_command
 
@@ -51,9 +51,6 @@ def initialize(workflow_workspace, operational_options):
             cache_enabled = False
     else:
         cache_enabled = False
-
-    # build workspace path
-    workflow_workspace = "{0}/{1}".format(SHARED_VOLUME_PATH, workflow_workspace)
 
     return workflow_workspace, cache_enabled
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2021.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, reana-commons
-reana-commons==0.8.0a17   # via reana-workflow-engine-serial (setup.py)
+reana-commons==0.8.0a21   # via reana-workflow-engine-serial (setup.py)
 requests==2.25.1          # via bravado
 rfc3987==1.3.8            # via jsonschema
 simplejson==3.17.2        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.0a5,<0.9.0",
+    "pytest-reana>=0.8.0a6,<0.9.0",
 ]
 
 extras_require = {
@@ -39,7 +39,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    "reana-commons>=0.8.0a17,<0.9.0",
+    "reana-commons>=0.8.0a21,<0.9.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Delete the dependency on SHARED_VOLUME_PATH by storing the full path inside the database, for serial, yadage and cwl engines.

Closes reanahub/reana-db#94