### PR TITLE
add global Kerberos propagation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 --------------------------
 
+- Adds support for propagating global Kerberos flag from workflow specification to each job.
 - Adds support for specifying ``slurm_partition`` and ``slurm_time`` for Slurm compute backend jobs.
 
 Version 0.8.1 (2022-02-07)

--- a/reana_workflow_engine_serial/config.py
+++ b/reana_workflow_engine_serial/config.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA Workflow Engine Serial config."""
 
+from distutils.util import strtobool
 import os
 
 MOUNT_CVMFS = os.getenv("REANA_MOUNT_CVMFS", "false")
@@ -17,3 +18,6 @@ JOB_STATUS_POLLING_INTERVAL = os.getenv("POLLING_INTERVAL", 3)
 
 CACHE_ENABLED = False
 """Determines if jobs caching is enabled."""
+
+WORKFLOW_KERBEROS = bool(strtobool(os.getenv("REANA_WORKFLOW_KERBEROS", "false")))
+"""Whether Kerberos is needed for the whole workflow."""

--- a/reana_workflow_engine_serial/tasks.py
+++ b/reana_workflow_engine_serial/tasks.py
@@ -17,7 +17,7 @@ from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
 from reana_commons.serial import serial_load
 from reana_commons.workflow_engine import create_workflow_engine_command
 
-from .config import CACHE_ENABLED
+from .config import CACHE_ENABLED, WORKFLOW_KERBEROS
 from .utils import (
     build_job_spec,
     check_cache,
@@ -113,7 +113,7 @@ def run_step(
             command=command,
             workflow_workspace=workflow_workspace,
             workflow_uuid=workflow_uuid,
-            kerberos=step.get("kerberos", False),
+            kerberos=step.get("kerberos", WORKFLOW_KERBEROS),
             unpacked_image=step.get("unpacked_image", False),
             kubernetes_uid=step.get("kubernetes_uid"),
             kubernetes_memory_limit=step.get("kubernetes_memory_limit"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pyrsistent==0.18.1        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core
 pytz==2022.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, reana-commons
-reana-commons==0.9.0a7    # via reana-workflow-engine-serial (setup.py)
+reana-commons==0.9.0a9	# via reana-workflow-engine-serial (setup.py)
 requests==2.27.1          # via bravado
 rfc3987==1.3.8            # via jsonschema
 simplejson==3.17.6        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.9.0a4,<0.10.0",
+    "pytest-reana>=0.9.0a5,<0.10.0",
 ]
 
 extras_require = {
@@ -46,7 +46,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    "reana-commons>=0.9.0a7,<0.10.0",
+    "reana-commons>=0.9.0a9,<0.10.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
closes #167 

How to test:

- follow https://github.com/reanahub/reana-workflow-controller/pull/448 instructions

- update `reana.yaml`

```diff
diff --git a/reana.yaml b/reana.yaml
index 50d1bd8..2b9126b 100644
--- a/reana.yaml
+++ b/reana.yaml
@@ -10,14 +10,13 @@ inputs:
     sleeptime: 0
 workflow:
   type: serial
+  resources:
+    kerberos: true
   specification:
     steps:
-      - environment: 'python:2.7-slim'
+      - environment: 'reanahub/krb5'
         commands:
-          - python "${helloworld}"
-              --inputfile "${inputfile}"
-              --outputfile "${outputfile}"
-              --sleeptime ${sleeptime}
+          - klist 2>&1; exit 0
 outputs:
   files:
    - results/greetings.txt
```