### PR TITLE
docs: add .readthedocs.yaml to migrate to RTD v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# This file is part of REANA.
+# Copyright (C) 2023 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,7 @@ include *.yaml
 include .flake8
 include pytest.ini
 include Dockerfile
+exclude .readthedocs.yaml
 prune docs/_build
 recursive-include reana_workflow_engine_serial *.py
 recursive-include reana_workflow_engine_serial *.json

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
     "docs": [
         "Sphinx>=1.5.1",
         "sphinx-rtd-theme>=0.1.9",
+        "Jinja2<3.1",
     ],
     "tests": tests_require,
 }


### PR DESCRIPTION
Closes reanahub/reana#710.