### PR TITLE
tests: allow execution of selected pytests only

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2023 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Workflow-Engine-Server tests."""
+
+from __future__ import absolute_import, print_function
+
+
+def test_version():
+    """Test version import."""
+    from reana_workflow_engine_serial import __version__
+
+    assert __version__


### PR DESCRIPTION
Allows execution of selected pytests via PYTESTARG environment variable. Example:

```
$ PYTESTARG=tests/test_version.py ./run-tests.sh --check-pytest
```

Adds forgotten test for version number.

Closes reanahub/reana#755.