### PR TITLE
build(python): drop support for Python 3.6 and 3.7 (#208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Check Python code formatting
         run: |
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Check compliance with pep8, pyflakes and circular complexity
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Check compliance with Python docstring conventions
         run: |
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Check Python manifest completeness
         run: |
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Install system dependencies
         run: |
@@ -148,7 +148,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Install Python dependencies
         run: |

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
             "reana_workflow_engine_serial.tasks:run_serial_workflow",
         ]
     },
+    python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
     setup_requires=setup_requires,


### PR DESCRIPTION
BREAKING CHANGE: drop support for Python 3.6 and 3.7

Closes reanahub/reana#784
