### PR TITLE
deprecations setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
         python3-dev \
         python3-pip \
         vim-tiny && \
-    pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir --upgrade pip 'setuptools<71' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
         gcc \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,7 +55,7 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    pytest
 }
 
 check_dockerfile () {

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "pytest-reana>=0.95.0a2,<0.96.0",
-]
-
 extras_require = {
     "debug": [
         "wdb",
@@ -34,7 +30,9 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
         "Jinja2<3.1",
     ],
-    "tests": tests_require,
+    "tests": [
+        "pytest-reana>=0.95.0a2,<0.96.0",
+    ],
 }
 
 extras_require["all"] = []
@@ -78,7 +76,6 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 install_requires = [
     "reana-commons>=0.95.0a2,<0.96.0",
 ]
@@ -82,7 +78,6 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#214)**
- **build(python): remove deprecated `pytest-runner` (#214)**
- **build(python): use optional deps instead of `tests_require` (#214)**
- **build(python): add minimal `pyproject.toml` (#214)**
- **build(docker): pin setuptools to v70 (#214)**

Closes https://github.com/reanahub/reana/issues/814
