### PR TITLE
ci(linting): add remaining linting and formatting checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,7 +12,6 @@ coverage:
         target: auto
         threshold: 2%
 
-
 parsers:
   gcov:
     branch_detection:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,17 @@ jobs:
           pip install check-manifest
           ./run-tests.sh --check-manifest
 
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --check-shfmt
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,20 @@ jobs:
           pip install check-manifest
           ./run-tests.sh --check-manifest
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --check-jsonlint
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,20 @@ jobs:
           npm install jsonlint --global
           ./run-tests.sh --check-jsonlint
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --check-markdownlint
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,24 @@ jobs:
           sudo apt-get install shfmt
           ./run-tests.sh --check-shfmt
 
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --check-yamllint
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:
@@ -235,4 +253,3 @@ jobs:
           platform: |
             linux/amd64
             linux/arm64
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,20 @@ jobs:
           sudo apt-get install shfmt
           ./run-tests.sh --check-shfmt
 
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code fomatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --check-prettier
+
   lint-yamllint:
     runs-on: ubuntu-24.04
     steps:
@@ -243,8 +257,7 @@ jobs:
   release-docker:
     runs-on: ubuntu-24.04
     if: >
-      vars.RELEASE_DOCKER == 'true' &&
-      github.event_name == 'push' &&
+      vars.RELEASE_DOCKER == 'true' && github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/')
     needs:
       - docs-sphinx

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,5 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+
+# Allow multiple headings with same content (for different releases)
+MD024: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.pytest_cache
+CHANGELOG.md
+docs/openapi.json

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,9 +5,13 @@
     ".": {
       "changelog-sections": [
         { "type": "build", "section": "Build", "hidden": false },
-        { "type": "feat", "section": "Features", "hidden": false  },
+        { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug fixes", "hidden": false },
-        { "type": "perf", "section": "Performance improvements", "hidden": false },
+        {
+          "type": "perf",
+          "section": "Performance improvements",
+          "hidden": false
+        },
         { "type": "refactor", "section": "Code refactoring", "hidden": false },
         { "type": "style", "section": "Code style", "hidden": false },
         { "type": "test", "section": "Test suite", "hidden": false },

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable -->
+
 # Changelog
 
 ## [0.9.4](https://github.com/reanahub/reana-workflow-engine-serial/compare/0.9.3...0.9.4) (2024-11-29)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome. If
+you find a demonstrable problem that is caused by the REANA code, please:
 
-1. Search for [already reported problems](https://github.com/reanahub/reana-workflow-engine-serial/issues).
-2. Check if the issue has been fixed or is still reproducible on the
-   latest `master` branch.
+1. Search for
+   [already reported problems](https://github.com/reanahub/reana-workflow-engine-serial/issues).
+2. Check if the issue has been fixed or is still reproducible on the latest
+   `master` branch.
 3. Create an issue, ideally with **a test case**.
 
 If you create a pull request fixing a bug or implementing a feature, you can run

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,8 @@ include LICENSE
 include pytest.ini
 exclude .readthedocs.yaml
 exclude .editorconfig
+exclude .prettierrc.yaml
+exclude .prettierignore
 prune docs/_build
 recursive-include reana_workflow_engine_serial *.py
 recursive-include reana_workflow_engine_serial *.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ include Dockerfile
 include LICENSE
 include pytest.ini
 exclude .readthedocs.yaml
+exclude .editorconfig
 prune docs/_build
 recursive-include reana_workflow_engine_serial *.py
 recursive-include reana_workflow_engine_serial *.json

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 ## About
 
-REANA-Workflow-Engine-Serial is a component of the [REANA](http://www.reana.io/) reusable
-and reproducible research data analysis platform. It takes care of instantiating,
-executing and managing simple sequential computational workflows.
+REANA-Workflow-Engine-Serial is a component of the [REANA](http://www.reana.io/)
+reusable and reproducible research data analysis platform. It takes care of
+instantiating, executing and managing simple sequential computational workflows.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+
 ```{include} ../README.md
 :end-before: "## About"
 ```

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -91,6 +91,10 @@ check_shfmt() {
     shfmt -d .
 }
 
+check_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 check_all() {
     check_commitlint
     check_shellcheck
@@ -105,6 +109,7 @@ check_all() {
     check_jsonlint
     check_yamllint
     check_shfmt
+    check_markdownlint
 }
 
 if [ $# -eq 0 ]; then
@@ -127,6 +132,7 @@ case $arg in
 --check-jsonlint) check_jsonlint ;;
 --check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
+--check-markdownlint) check_markdownlint ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -83,6 +83,10 @@ check_jsonlint() {
     find . -name "*.json" -exec jsonlint -q {} \+
 }
 
+check_yamllint() {
+    yamllint .
+}
+
 check_shfmt() {
     shfmt -d .
 }
@@ -99,6 +103,7 @@ check_all() {
     check_dockerfile
     check_docker_build
     check_jsonlint
+    check_yamllint
     check_shfmt
 }
 
@@ -120,6 +125,7 @@ case $arg in
 --check-dockerfile) check_dockerfile ;;
 --check-docker-build) check_docker_build ;;
 --check-jsonlint) check_jsonlint ;;
+--check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -95,6 +95,10 @@ check_markdownlint() {
     markdownlint-cli2 "**/*.md"
 }
 
+check_prettier() {
+    prettier -c .
+}
+
 check_all() {
     check_commitlint
     check_shellcheck
@@ -110,6 +114,7 @@ check_all() {
     check_yamllint
     check_shfmt
     check_markdownlint
+    check_prettier
 }
 
 if [ $# -eq 0 ]; then
@@ -133,6 +138,7 @@ case $arg in
 --check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
 --check-markdownlint) check_markdownlint ;;
+--check-prettier) check_prettier ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -79,6 +79,10 @@ check_docker_build() {
     docker build -t docker.io/reanahub/reana-workflow-engine-serial .
 }
 
+check_jsonlint() {
+    find . -name "*.json" -exec jsonlint -q {} \+
+}
+
 check_shfmt() {
     shfmt -d .
 }
@@ -94,6 +98,7 @@ check_all() {
     check_pytest
     check_dockerfile
     check_docker_build
+    check_jsonlint
     check_shfmt
 }
 
@@ -114,6 +119,7 @@ case $arg in
 --check-pytest) check_pytest ;;
 --check-dockerfile) check_dockerfile ;;
 --check-docker-build) check_docker_build ;;
+--check-jsonlint) check_jsonlint ;;
 --check-shfmt) check_shfmt ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+check_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
@@ -31,7 +31,7 @@ check_commitlint () {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -43,43 +43,47 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+check_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_pydocstyle () {
+check_pydocstyle() {
     pydocstyle reana_workflow_engine_serial
 }
 
-check_black () {
+check_black() {
     black --check .
 }
 
-check_flake8 () {
+check_flake8() {
     flake8 .
 }
 
-check_manifest () {
+check_manifest() {
     check-manifest
 }
 
-check_sphinx () {
+check_sphinx() {
     sphinx-build -qnNW docs docs/_build/html
 }
 
-check_pytest () {
+check_pytest() {
     pytest
 }
 
-check_dockerfile () {
-    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
+check_dockerfile() {
+    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
 }
 
-check_docker_build () {
+check_docker_build() {
     docker build -t docker.io/reanahub/reana-workflow-engine-serial .
 }
 
-check_all () {
+check_shfmt() {
+    shfmt -d .
+}
+
+check_all() {
     check_commitlint
     check_shellcheck
     check_pydocstyle
@@ -90,6 +94,7 @@ check_all () {
     check_pytest
     check_dockerfile
     check_docker_build
+    check_shfmt
 }
 
 if [ $# -eq 0 ]; then
@@ -99,15 +104,17 @@ fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-pydocstyle) check_pydocstyle;;
-    --check-black) check_black;;
-    --check-flake8) check_flake8;;
-    --check-manifest) check_manifest;;
-    --check-sphinx) check_sphinx;;
-    --check-pytest) check_pytest;;
-    --check-dockerfile) check_dockerfile;;
-    --check-docker-build) check_docker_build;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--check-commitlint) check_commitlint "$@" ;;
+--check-shellcheck) check_shellcheck ;;
+--check-pydocstyle) check_pydocstyle ;;
+--check-black) check_black ;;
+--check-flake8) check_flake8 ;;
+--check-manifest) check_manifest ;;
+--check-sphinx) check_sphinx ;;
+--check-pytest) check_pytest ;;
+--check-dockerfile) check_dockerfile ;;
+--check-docker-build) check_docker_build ;;
+--check-shfmt) check_shfmt ;;
+--check-all) check_all ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac


### PR DESCRIPTION
Introduce remaining file formatting checks to `run-tests.sh` and to the GitHub CI:
- [x] `.editorconfig` for consistent character formatting across the repo
- [x] `yamllint` for YAML linting
- [x] `jsonlint` for JSON linting
- [x] `shfmt` for shell script formatting
- [x] `markdownlint` for markdown linting
- [x] `prettier` for various other formatting such as `.js` files

Closes #230