### PR TITLE
refactor(pytest): drop pytest-reana for reana-commons[tests]

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --ignore=docs --cov=reana_workflow_engine_serial --cov-report=term-missing  --cov-report=xml
+addopts = --ignore=docs --ignore=modules --cov=reana_workflow_engine_serial --cov-report=term-missing  --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ parse==1.21.1             # via reana-commons
 python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core
 pytz==2026.1.post1        # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, reana-commons, swagger-spec-validator
-reana-commons==0.95.0a14  # via reana-workflow-engine-serial (setup.py)
+reana-commons==0.95.0a16	# via reana-workflow-engine-serial (setup.py)
 referencing==0.37.0       # via jsonschema, jsonschema-specifications
 requests==2.33.0          # via bravado, bravado-core
 rfc3339-validator==0.1.4  # via jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,53 +6,47 @@
 #
 amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs
-arrow==1.4.0              # via isoduration
-attrs==26.1.0             # via jsonschema, referencing
+attrs==26.1.0             # via jsonschema
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
-certifi==2026.2.25        # via requests
-charset-normalizer==3.4.6  # via requests
+certifi==2026.4.22        # via requests
+charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
-click==8.3.1              # via reana-commons
-fqdn==1.5.1               # via jsonschema
+click==8.3.3              # via reana-commons
 fs==2.4.16                # via reana-commons
-gherkin-official==39.0.0  # via reana-commons
-idna==3.11                # via jsonschema, requests
-importlib-resources==6.5.2  # via swagger-spec-validator
-isoduration==20.11.0      # via jsonschema
+gherkin-official==39.1.0  # via reana-commons
+idna==3.14                # via jsonschema, requests
+importlib-resources==7.1.0  # via swagger-spec-validator
 jsonpointer==3.1.1        # via jsonschema
 jsonref==1.1.0            # via bravado-core
-jsonschema[format]==4.26.0  # via bravado-core, reana-commons, swagger-spec-validator
-jsonschema-specifications==2025.9.1  # via jsonschema
+jsonschema[format]==3.2.0  # via bravado-core, reana-commons, swagger-spec-validator
 kombu==5.6.2              # via reana-commons
 markupsafe==3.0.3         # via werkzeug
 mock==3.0.5               # via reana-commons
 monotonic==1.6            # via bravado
 msgpack==1.1.2            # via bravado-core
 msgpack-python==0.5.6     # via bravado
-packaging==26.0           # via kombu
-parse==1.21.1             # via reana-commons
-python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core
-pytz==2026.1.post1        # via bravado-core
+packaging==26.2           # via kombu
+parse==1.22.0             # via reana-commons
+pyrsistent==0.20.0        # via jsonschema
+python-dateutil==2.9.0.post0  # via bravado, bravado-core
+pytz==2026.2              # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, reana-commons, swagger-spec-validator
-reana-commons==0.95.0a16	# via reana-workflow-engine-serial (setup.py)
-referencing==0.37.0       # via jsonschema, jsonschema-specifications
-requests==2.33.0          # via bravado, bravado-core
-rfc3339-validator==0.1.4  # via jsonschema
+reana-commons==0.95.0a16  # via reana-workflow-engine-serial (setup.py)
+requests==2.34.0          # via bravado, bravado-core
 rfc3987==1.3.8            # via jsonschema
-rpds-py==0.30.0           # via jsonschema, referencing
-simplejson==3.20.2        # via bravado, bravado-core
-six==1.17.0               # via bravado, bravado-core, fs, mock, python-dateutil, rfc3339-validator
+simplejson==4.1.1         # via bravado, bravado-core
+six==1.17.0               # via bravado, bravado-core, fs, jsonschema, mock, python-dateutil
+strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
-typing-extensions==4.15.0  # via bravado, gherkin-official, referencing, swagger-spec-validator
-tzdata==2025.3            # via arrow, kombu
-uri-template==1.3.0       # via jsonschema
-urllib3==2.6.3            # via requests
+typing-extensions==4.15.0  # via bravado, gherkin-official, swagger-spec-validator
+tzdata==2026.2            # via kombu
+urllib3==2.7.0            # via requests
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webcolors==25.10.0        # via jsonschema
-werkzeug==3.1.7           # via reana-commons
+werkzeug==3.1.8           # via reana-commons
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
         "Jinja2<3.1",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a2,<0.96.0",
+        "reana-commons[tests]>=0.95.0a16,<0.96.0",
     ],
 }
 
@@ -42,7 +42,7 @@ for key, reqs in extras_require.items():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    "reana-commons>=0.95.0a14,<0.96.0",
+    "reana-commons>=0.95.0a16,<0.96.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
The serial engine's tests/conftest.py depends on the serial_workflow
fixture, which has been relocated into reana_commons.testing. Replace
pytest-reana with reana-commons[tests] in extras_require[tests]; the
fixture auto-loads via reana-commons' new pytest11 entry point.

Closes https://github.com/reanahub/pytest-reana/issues/156