### PR TITLE
fix(git): update .gitignore to exclude modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ target/
 # IntelliJ project files
 .idea
 *.iml
+
+# REANA modules for local development
+modules/

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,6 +4,7 @@ The list of contributors in alphabetical order:
 
 - [Adelina Lintuluoto](https://orcid.org/0000-0002-0726-1452)
 - [Agisilaos Kounelis](https://orcid.org/0000-0001-9312-3189)
+- [Alexander Sohn](https://orcid.org/0009-0000-3673-4637)
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)


### PR DESCRIPTION
For local development we populate the modules directory with local versions of shared REANA modules (reana-commons, reana-db) so that changes to shared modules are reflected in each component. This led to a lot of untracked files, which was confusing for new developers.

Closes reanahub/reana#963