### PR TITLE
feat(tasks): pass HTCondor CPU/memory/disk/requirements hints

### DIFF
--- a/reana_workflow_engine_serial/tasks.py
+++ b/reana_workflow_engine_serial/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -126,6 +126,10 @@ def run_step(
             rucio=step.get("rucio", False),
             htcondor_max_runtime=step.get("htcondor_max_runtime", ""),
             htcondor_accounting_group=step.get("htcondor_accounting_group", ""),
+            htcondor_request_cpus=step.get("htcondor_request_cpus", ""),
+            htcondor_request_memory=step.get("htcondor_request_memory", ""),
+            htcondor_request_disk=step.get("htcondor_request_disk", ""),
+            htcondor_requirements=step.get("htcondor_requirements", ""),
             slurm_partition=step.get("slurm_partition"),
             slurm_time=step.get("slurm_time"),
             c4p_cpu_cores=step.get("c4p_cpu_cores"),

--- a/reana_workflow_engine_serial/utils.py
+++ b/reana_workflow_engine_serial/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -37,6 +37,10 @@ def build_job_spec(
     rucio,
     htcondor_max_runtime,
     htcondor_accounting_group,
+    htcondor_request_cpus,
+    htcondor_request_memory,
+    htcondor_request_disk,
+    htcondor_requirements,
     slurm_partition,
     slurm_time,
     c4p_cpu_cores,
@@ -65,6 +69,10 @@ def build_job_spec(
         "rucio": rucio,
         "htcondor_max_runtime": htcondor_max_runtime,
         "htcondor_accounting_group": htcondor_accounting_group,
+        "htcondor_request_cpus": htcondor_request_cpus,
+        "htcondor_request_memory": htcondor_request_memory,
+        "htcondor_request_disk": htcondor_request_disk,
+        "htcondor_requirements": htcondor_requirements,
         "slurm_partition": slurm_partition,
         "slurm_time": slurm_time,
         "c4p_cpu_cores": c4p_cpu_cores,


### PR DESCRIPTION
Reads the four new HTCondor step parameters from the Serial workflow
specification and forwards them to reana-job-controller via the shared
API client:

* htcondor_request_cpus
* htcondor_request_memory
* htcondor_request_disk
* htcondor_requirements

Pass-through only; lightweight validation lives in reana-commons, while
unit conversion and ClassAd parsing live in reana-job-controller.

Closes reanahub/reana-job-controller#502
